### PR TITLE
Fixed broken mii studio mode + various fixes

### DIFF
--- a/mii2studio.py
+++ b/mii2studio.py
@@ -1,6 +1,4 @@
-import subprocess
 import sys
-import codecs
 from binascii import hexlify
 from os import remove
 from requests import get, post
@@ -306,20 +304,15 @@ with open(output_file, "wb") as f:
             mii_dict.append(int(read[i:i+2], 16))
     else:
         mii_dict = studio_mii.values()
-#    mii_data_bytes += hexlify(u8(0))
     mii_data += hexlify(u8(0))
     for v in mii_dict:
         eo = (7 + (v ^ n)) % 256 # encode the Mii, Nintendo seemed to have randomized the encoding using Math.random() in JS, but we removed randomizing
         n = eo
-#        mii_data_bytes += hexlify(u8(mii_dict))
         mii_data += hexlify(u8(eo))
         f.write(u8(v))
         mii_data_bytes += str(hexlify(u8(v)), "ascii")
 
     f.close()
-    
-    #codecs.decode(mii_data_bytes, "hex")
-    #mii_data_bytes = mii_data_bytes.decode("utf-8")
     
     url = "https://studio.mii.nintendo.com/miis/image.png?data=" + mii_data.decode("utf-8")
 

--- a/mii2studio.py
+++ b/mii2studio.py
@@ -17,6 +17,9 @@ else:
     output_file = sys.argv[2]
     input_type = sys.argv[3]
 
+if input_type == "miistudio": # for legacy reasons
+    input_type = "studio"
+
 if input_type == "wii":
     from gen1_wii import CoreDataWii
     try:
@@ -98,7 +101,7 @@ elif input_type == "switchdb":
 elif input_type == "switch":
     from gen3_switchgame import CharInfoSwitch
     orig_mii = CharInfoSwitch.from_file(input_file)
-elif input_type == "miistudio":
+elif input_type == "studio":
     from gen3_studio import MiidataStudio
     orig_mii = MiidataStudio.from_file(input_file)
 else:
@@ -294,7 +297,7 @@ with open(output_file, "wb") as f:
     mii_data = b""
     n = r = 256
     mii_dict = []
-    if input_type == "miistudio":
+    if input_type == "studio":
         with open(input_file, "rb") as g:
             read = g.read()
             g.close()

--- a/mii2studio.py
+++ b/mii2studio.py
@@ -302,8 +302,8 @@ with open(output_file, "wb") as f:
             read = g.read()
             g.close()
         
-        for i in range(0, len(hexlify(read)), 2):
-            mii_dict.append(int(hexlify(read)[i:i+2], 16))
+        for i in range(0, len(read), 2): # 2 characters = 1 byte in hex
+            mii_dict.append(int(read[i:i+2], 16))
     else:
         mii_dict = studio_mii.values()
 #    mii_data_bytes += hexlify(u8(0))

--- a/mii2studio.py
+++ b/mii2studio.py
@@ -97,10 +97,10 @@ elif input_type == "switchdb":
     orig_mii = CoreDataSwitch.from_file(input_file)
 elif input_type == "switch":
     from gen3_switchgame import CharInfoSwitch
-    orig_mii = CharInfoSwitch.from_file(sys.argv[1])
+    orig_mii = CharInfoSwitch.from_file(input_file)
 elif input_type == "miistudio":
     from gen3_studio import MiidataStudio
-    orig_mii = MiidataStudio.from_file(sys.argv[1])
+    orig_mii = MiidataStudio.from_file(input_file)
 else:
     print("Error: Invalid input type.")
     exit()


### PR DESCRIPTION
 - Fixed borked mii studio mode caused by bad file read
   - instead of turning each pair of hex digits into a byte, it turned the *ascii hex representation of each hex digit* into a byte
 - Fixed an inconsistent use of both "miistudio" and "studio" as input types
   - "miistudio" still works, `input_type` will be re-set to "studio" in that case
 - Fixed a IndexError resulting in a crash in noargs / "step by step" mode
   -  some places attempted to get the input file from `sys.argv[1]` instead of using the `input_file` variable
 - Removed unused imports and leftovers from previous versions