### PR TITLE
fix inaccuracies in gen2_wiiu_3ds_miitomo.ksy

### DIFF
--- a/gen2_wiiu_3ds_miitomo.ksy
+++ b/gen2_wiiu_3ds_miitomo.ksy
@@ -159,11 +159,11 @@ instances:
   glasses_vertical:
     value: glasses >> 11 & 15
   glasses_size:
-    value: glasses >> 7 & 11
+    value: glasses >> 7 & 15
   glasses_color:
     value: glasses >> 4 & 7
   glasses_type:
-    value: glasses & 4
+    value: glasses & 15
   mole_vertical:
     value: mole >> 10 & 31
   mole_horizontal:
@@ -171,4 +171,4 @@ instances:
   mole_size:
     value: mole >> 1 & 15
   mole_enable:
-    value: mole >> 15
+    value: mole >> 0 & 1


### PR DESCRIPTION
These changes are reflected in the compiled Python version of the ksy, but not the actual specification itself - causing problems when compiling for other languages.